### PR TITLE
closes #23; allows blocks with same permutations; adds relevant tests

### DIFF
--- a/R/obtain_permutation_matrix.R
+++ b/R/obtain_permutation_matrix.R
@@ -109,8 +109,9 @@ obtain_permutation_matrix <-
       perms_by_block <- mapply(FUN = complete_ra_permutations,
                                ns_per_block_list,
                                block_prob_each_local,
-                               condition_names_list)
-      
+                               condition_names_list,
+                               SIMPLIFY = FALSE)
+
       perms <-
         Reduce(expand_matrix, x = perms_by_block)
       
@@ -176,7 +177,8 @@ obtain_permutation_matrix <-
       perms_by_block <- mapply(FUN = complete_ra_permutations,
                                ns_per_block_list,
                                block_prob_each_local,
-                               condition_names_list)
+                               condition_names_list,
+                               SIMPLIFY = FALSE)
       
       perms <-
         Reduce(expand_matrix, x = perms_by_block)

--- a/tests/testthat/test-permutations.R
+++ b/tests/testthat/test-permutations.R
@@ -63,7 +63,7 @@ dim(perms)
 obtain_num_permutations(declaration)
 obtain_permutation_probabilities(declaration)
 
-# blocked -----------------------------------------------------------------
+# blocked, diff size group --------------------------------------------------
 
 block_var <- c("A", "A", "B", "B", "C", "C", "C")
 declaration <- declare_ra(block_var = block_var)
@@ -72,8 +72,16 @@ dim(perms)
 obtain_num_permutations(declaration)
 obtain_permutation_probabilities(declaration)
 
+# blocked, same size group --------------------------------------------------
 
-# clustered
+block_var <- c("A", "A", "B", "B", "C", "C")
+declaration <- declare_ra(block_var = block_var)
+perms <- obtain_permutation_matrix(declaration)
+dim(perms)
+obtain_num_permutations(declaration)
+obtain_permutation_probabilities(declaration)
+
+# clustered, diff size clusters --------------------------------------------------
 
 clust_var <- c("A", "B", "A", "B", "C", "C", "C")
 declaration <- declare_ra(clust_var = clust_var)
@@ -82,6 +90,38 @@ dim(perms)
 obtain_num_permutations(declaration)
 obtain_permutation_probabilities(declaration)
 
+# clustered, same size clusters --------------------------------------------------
+
+clust_var <- c("A", "B", "A", "B", "C", "C")
+declaration <- declare_ra(clust_var = clust_var)
+perms <- obtain_permutation_matrix(declaration)
+dim(perms)
+obtain_num_permutations(declaration)
+obtain_permutation_probabilities(declaration)
+
+
+# block clustered, simple ----------------------------------------
+
+clust_var <- c("A", "B", "A", "B", "C", "C", "D", "D")
+block_var <- rep(1:2, each = 4)
+declaration <- declare_ra(clust_var = clust_var,
+                          block_var = block_var)
+perms <- obtain_permutation_matrix(declaration)
+dim(perms)
+obtain_num_permutations(declaration)
+obtain_permutation_probabilities(declaration)
+
+
+# block clustered, uneven ----------------------------------------
+
+clust_var <- c("A", "B", "A", "B", "C", "C", "D", "D", "D", "E", "E")
+block_var <- rep(1:2, times = c(4, 7))
+declaration <- declare_ra(clust_var = clust_var,
+                          block_var = block_var)
+perms <- obtain_permutation_matrix(declaration)
+dim(perms)
+obtain_num_permutations(declaration)
+obtain_permutation_probabilities(declaration)
 
 # test against RI package
 


### PR DESCRIPTION
The problem with getting the permutation matrix as described in issue #23 was with the `mapply`. If the block randomization was the same in every block and every block was the same, then  `complete_ra_permutations` returned the same matrix for every block. `mapply` would then simplify that list of identical matrices to be a single matrix. This broke `Reduce(expand_matrix, x = perms_by_block)` because it was being passed one matrix instead of a list of matrices.

I also added tests that would have caught this and now pass.