### PR TITLE
This pr finishes the *_unit argument additions

### DIFF
--- a/R/block_ra.R
+++ b/R/block_ra.R
@@ -33,11 +33,21 @@
 #'
 #' Z <- block_ra(blocks = blocks, block_prob = c(.1, .2, .3))
 #' table(blocks, Z)
+#' 
+#' Z <- block_ra(blocks = blocks, 
+#'               prob_unit = rep(c(.1, .2, .3), 
+#'                               times = c(50, 100, 200)))
+#' table(blocks, Z)
 #'
 #' Z <- block_ra(blocks = blocks, m = 20)
 #' table(blocks, Z)
 #'
 #' Z <- block_ra(blocks = blocks, block_m = c(20, 30, 40))
+#' table(blocks, Z)
+#' 
+#' Z <- block_ra(blocks = blocks, 
+#'               m_unit = rep(c(20, 30, 40),
+#'                            times = c(50, 100, 200)))
 #' table(blocks, Z)
 #'
 #' block_m_each <- rbind(c(25, 25),
@@ -203,7 +213,7 @@ block_ra_probabilities <- function(blocks = NULL,
   block_spots <-
     unlist(split(seq_along(blocks), blocks), FALSE, FALSE)
   
-  blocks <- sort(unique(blocks))
+  # blocks <- sort(unique(blocks))
 
   mapply_args <- list(
     FUN = "complete_ra_probabilities",
@@ -254,7 +264,6 @@ block_ra_helper <- function(blocks = NULL,
                      num_arms = NULL,
                      N_per_block, 
                      mapply_args) {
-
   
   if(!is.null(prob_unit)){
     block_prob <- tapply(prob_unit, blocks, unique)

--- a/R/cluster_ra.R
+++ b/R/cluster_ra.R
@@ -61,7 +61,9 @@ cluster_ra <- function(clusters = NULL,
   n_per_clust <- tapply(clusters, clusters, length)
   n_clust <- length(n_per_clust)
   
-  if(!is.null(m_unit)){m_unit <- rep(unique(m_unit), n_clust)}
+  if(!is.null(m_unit)) {
+    m_unit <- rep(unique(m_unit), n_clust)
+  }
   
   delegate_args <- list(
     N = n_clust,

--- a/R/cluster_rs.R
+++ b/R/cluster_rs.R
@@ -28,8 +28,9 @@ cluster_rs <- function(clusters = NULL,
                        prob_unit = NULL,
                        simple = FALSE,
                        check_inputs = TRUE) {
-  if (check_inputs)
+  if (check_inputs){
     .invoke_check(check_samplr_arguments_new)
+  }
   
   n_per_clust <- tapply(clusters, clusters, length)
   unique_clust <- names(n_per_clust)
@@ -101,10 +102,10 @@ cluster_rs_probabilities <-
     
     
     if (!is.null(prob_unit)) {
-      prob_unit <- tapply(prob_unit, INDEX = clusters, FUN = unique)
+      prob_unit <- tapply(prob_unit, INDEX = clusters, FUN = unique, simplify = FALSE)
     }
     if (!is.null(n_unit)) {
-      n_unit <- tapply(n_unit, INDEX = clusters, FUN = unique)
+      n_unit <- tapply(n_unit, INDEX = clusters, FUN = unique, simplify = FALSE)
     }
     
     if (simple) {

--- a/R/cluster_rs.R
+++ b/R/cluster_rs.R
@@ -28,7 +28,8 @@ cluster_rs <- function(clusters = NULL,
                        prob_unit = NULL,
                        simple = FALSE,
                        check_inputs = TRUE) {
-  if (check_inputs) .invoke_check(check_samplr_arguments_new)
+  if (check_inputs)
+    .invoke_check(check_samplr_arguments_new)
   
   n_per_clust <- tapply(clusters, clusters, length)
   unique_clust <- names(n_per_clust)
@@ -37,20 +38,25 @@ cluster_rs <- function(clusters = NULL,
   if (!is.null(prob_unit)) {
     prob_unit <- tapply(prob_unit, INDEX = clusters, FUN = unique)
   }
+  
   if (!is.null(n_unit)) {
-    n <- unique(n_unit)
+    n_unit <- tapply(n_unit, INDEX = clusters, FUN = unique)
   }
   
   if (simple) {
-    S_clust <- simple_rs(N = n_clust, prob = prob, prob_unit = prob_unit)
+    S_clust <-
+      simple_rs(N = n_clust,
+                prob = prob,
+                prob_unit = prob_unit)
     
   } else{
-    
-    S_clust <- complete_rs(N = n_clust,
-                           n = n,
-                           n_unit = n_unit,
-                           prob = prob,
-                           prob_unit = prob_unit)
+    S_clust <- complete_rs(
+      N = n_clust,
+      n = n,
+      n_unit = n_unit,
+      prob = prob,
+      prob_unit = prob_unit
+    )
   }
   assignment <- rep(S_clust, n_per_clust)
   assignment <-
@@ -86,7 +92,8 @@ cluster_rs_probabilities <-
            prob_unit = NULL,
            simple = FALSE,
            check_inputs = TRUE) {
-    if (check_inputs) .invoke_check(check_samplr_arguments_new)
+    if (check_inputs)
+      .invoke_check(check_samplr_arguments_new)
     
     n_per_clust <- tapply(clusters, clusters, length)
     unique_clust <- names(n_per_clust)
@@ -97,7 +104,7 @@ cluster_rs_probabilities <-
       prob_unit <- tapply(prob_unit, INDEX = clusters, FUN = unique)
     }
     if (!is.null(n_unit)) {
-      n <- unique(n_unit)
+      n_unit <- tapply(n_unit, INDEX = clusters, FUN = unique)
     }
     
     if (simple) {
@@ -107,17 +114,18 @@ cluster_rs_probabilities <-
                                 prob_unit = prob_unit)
     } else{
       probs_clust <-
-        complete_rs_probabilities(N = n_clust,
-                                  n = n,
-                                  n_unit = n_unit,
-                                  prob = prob,
-                                  prob_unit = prob_unit)
+        complete_rs_probabilities(
+          N = n_clust,
+          n = n,
+          n_unit = n_unit,
+          prob = prob,
+          prob_unit = prob_unit
+        )
     }
-    
     
     prob_vec <- rep(probs_clust, n_per_clust)
     prob_vec <-
-      prob_vec[order(unlist(split(seq_along(clusters), clusters), 
+      prob_vec[order(unlist(split(seq_along(clusters), clusters),
                             FALSE, FALSE))]
     return(prob_vec)
   }

--- a/R/complete_ra.R
+++ b/R/complete_ra.R
@@ -29,8 +29,14 @@
 #'
 #' Z <- complete_ra(N = 100, m = 50)
 #' table(Z)
+#' 
+#' Z <- complete_ra(N = 100, m_unit = rep(50, 100))
+#' table(Z)
 #'
 #' Z <- complete_ra(N = 100, prob = .111)
+#' table(Z)
+#' 
+#' Z <- complete_ra(N = 100, prob_unit = rep(0.1, 100))
 #' table(Z)
 #'
 #' Z <- complete_ra(N = 100, conditions = c("control", "treatment"))

--- a/R/complete_rs.R
+++ b/R/complete_rs.R
@@ -23,10 +23,16 @@
 #'
 #' S <- complete_rs(N = 100, n = 50)
 #' table(S)
+#' 
+#' S <- complete_rs(N = 100, n_unit = rep(50, 100))
+#' table(S)
 #'
 #' S <- complete_rs(N = 100, prob = .111)
 #' table(S)
-#'
+#' 
+#' S <- complete_rs(N = 100, prob_unit = rep(.1, 100))
+#' table(S)
+#' 
 #' # If N = n, sample with 100% probability...
 #' complete_rs(N=2, n=2)
 #'

--- a/R/generated_methods.R
+++ b/R/generated_methods.R
@@ -3,8 +3,10 @@ ra_function.ra_blocked <-
     block_ra(
       blocks = this[["blocks"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       m = this[["m"]],
+      m_unit = this[["m_unit"]],
       block_m = this[["block_m"]],
       block_m_each = this[["block_m_each"]],
       block_prob = this[["block_prob"]],
@@ -19,8 +21,10 @@ ra_function.ra_blocked_and_clustered <-
       blocks = this[["blocks"]],
       clusters = this[["clusters"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       m = this[["m"]],
+      m_unit = this[["m_unit"]],
       block_m = this[["block_m"]],
       block_m_each = this[["block_m_each"]],
       block_prob = this[["block_prob"]],
@@ -34,8 +38,10 @@ ra_function.ra_clustered <-
     cluster_ra(
       clusters = this[["clusters"]],
       m = this[["m"]],
+      m_unit = this[["m_unit"]],
       m_each = this[["m_each"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       num_arms = this[["num_arms"]],
       conditions = this[["conditions"]],
@@ -47,8 +53,10 @@ ra_function.ra_complete <-
     complete_ra(
       N = this[["N"]],
       m = this[["m"]],
+      m_unit = this[["m_unit"]],
       m_each = this[["m_each"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       num_arms = this[["num_arms"]],
       conditions = this[["conditions"]],
@@ -62,18 +70,22 @@ ra_function.ra_simple <-
     simple_ra(
       N = this[["N"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       num_arms = this[["num_arms"]],
       conditions = this[["conditions"]],
-      check_inputs = this[["check_inputs"]]
+      check_inputs = this[["check_inputs"]],
+      simple = this[["simple"]]
     )
 ra_probabilities.ra_blocked <-
   function (this)
     block_ra_probabilities(
       blocks = this[["blocks"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       m = this[["m"]],
+      m_unit = this[["m_unit"]],
       block_m = this[["block_m"]],
       block_m_each = this[["block_m_each"]],
       block_prob = this[["block_prob"]],
@@ -88,8 +100,10 @@ ra_probabilities.ra_blocked_and_clustered <-
       blocks = this[["blocks"]],
       clusters = this[["clusters"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       m = this[["m"]],
+      m_unit = this[["m_unit"]],
       block_m = this[["block_m"]],
       block_m_each = this[["block_m_each"]],
       block_prob = this[["block_prob"]],
@@ -103,8 +117,10 @@ ra_probabilities.ra_clustered <-
     cluster_ra_probabilities(
       clusters = this[["clusters"]],
       m = this[["m"]],
+      m_unit = this[["m_unit"]],
       m_each = this[["m_each"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       num_arms = this[["num_arms"]],
       conditions = this[["conditions"]],
@@ -116,8 +132,10 @@ ra_probabilities.ra_complete <-
     complete_ra_probabilities(
       N = this[["N"]],
       m = this[["m"]],
+      m_unit = this[["m_unit"]],
       m_each = this[["m_each"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       num_arms = this[["num_arms"]],
       conditions = this[["conditions"]],
@@ -131,17 +149,21 @@ ra_probabilities.ra_simple <-
     simple_ra_probabilities(
       N = this[["N"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       prob_each = this[["prob_each"]],
       num_arms = this[["num_arms"]],
       conditions = this[["conditions"]],
-      check_inputs = this[["check_inputs"]]
+      check_inputs = this[["check_inputs"]],
+      simple = this[["simple"]]
     )
 rs_function.rs_clustered <-
   function (this)
     cluster_rs(
       clusters = this[["clusters"]],
       n = this[["n"]],
+      n_unit = this[["n_unit"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       simple = this[["simple"]],
       check_inputs = this[["check_inputs"]]
     )
@@ -150,20 +172,26 @@ rs_function.rs_complete <-
     complete_rs(
       N = this[["N"]],
       n = this[["n"]],
+      n_unit = this[["n_unit"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       check_inputs = this[["check_inputs"]]
     )
 rs_function.rs_simple <-
   function (this)
     simple_rs(N = this[["N"]],
               prob = this[["prob"]],
-              check_inputs = this[["check_inputs"]])
+              prob_unit = this[["prob_unit"]],
+              check_inputs = this[["check_inputs"]],
+              simple = this[["simple"]])
 rs_function.rs_stratified <-
   function (this)
     strata_rs(
       strata = this[["strata"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       n = this[["n"]],
+      n_unit = this[["n_unit"]],
       strata_n = this[["strata_n"]],
       strata_prob = this[["strata_prob"]],
       check_inputs = this[["check_inputs"]]
@@ -174,7 +202,9 @@ rs_function.rs_stratified_and_clustered <-
       strata = this[["strata"]],
       clusters = this[["clusters"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       n = this[["n"]],
+      n_unit = this[["n_unit"]],
       strata_n = this[["strata_n"]],
       strata_prob = this[["strata_prob"]],
       check_inputs = this[["check_inputs"]]
@@ -184,7 +214,9 @@ rs_probabilities.rs_clustered <-
     cluster_rs_probabilities(
       clusters = this[["clusters"]],
       n = this[["n"]],
+      n_unit = this[["n_unit"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       simple = this[["simple"]],
       check_inputs = this[["check_inputs"]]
     )
@@ -193,20 +225,26 @@ rs_probabilities.rs_complete <-
     complete_rs_probabilities(
       N = this[["N"]],
       n = this[["n"]],
+      n_unit = this[["n_unit"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       check_inputs = this[["check_inputs"]]
     )
 rs_probabilities.rs_simple <-
   function (this)
     simple_rs_probabilities(N = this[["N"]],
                             prob = this[["prob"]],
-                            check_inputs = this[["check_inputs"]])
+                            prob_unit = this[["prob_unit"]],
+                            check_inputs = this[["check_inputs"]],
+                            simple = this[["simple"]])
 rs_probabilities.rs_stratified <-
   function (this)
     strata_rs_probabilities(
       strata = this[["strata"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       n = this[["n"]],
+      n_unit = this[["n_unit"]],
       strata_n = this[["strata_n"]],
       strata_prob = this[["strata_prob"]],
       check_inputs = this[["check_inputs"]]
@@ -217,7 +255,9 @@ rs_probabilities.rs_stratified_and_clustered <-
       strata = this[["strata"]],
       clusters = this[["clusters"]],
       prob = this[["prob"]],
+      prob_unit = this[["prob_unit"]],
       n = this[["n"]],
+      n_unit = this[["n_unit"]],
       strata_n = this[["strata_n"]],
       strata_prob = this[["strata_prob"]],
       check_inputs = this[["check_inputs"]]

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -2,13 +2,16 @@
 
 
 
+
 # Call check() with all formal arguments of the invoking function
 # reinsert results into that environment
 .invoke_check <- function(check) {
+  browser()
   definition <- sys.function(sys.parent())
   envir <- parent.frame(1)
   
   all_args <- mget(names(formals(definition)), envir)
+  if(blah) all_args$simple <- TRUE
   ret <- check(all_args)
   list2env(ret, envir)
   invisible(NULL)
@@ -41,14 +44,13 @@ check_randomizr_arguments <-
            conditions = NULL,
            ...) {
     # N, blocks, clusters, num_arms, conditions are used generally, check them first
-    
     if (!is.null(clusters)) {
       N <- length(unique(clusters))
     }
     
     if (!is.null(blocks)) {
       if (isTRUE(simple))
-        stop("You can't specify `simple` when using blocked assignment",
+        stop("You can't specify `simple` when using blocked assignment.",
              call. = FALSE)
       
       if (!is.null(clusters)) {
@@ -69,7 +71,7 @@ check_randomizr_arguments <-
       if (is.null(N)) {
         N <- sum(N_per_block)
       } else if (N != sum(N_per_block)) {
-        stop("N should equal the length of blocks", call. = FALSE)
+        stop("N should equal the length of blocks.", call. = FALSE)
       }
       
       N_blocks <- length(N_per_block)
@@ -131,7 +133,7 @@ check_randomizr_arguments <-
       
       if (isTRUE(simple) &&
           !grepl("prob", arg))
-        stop("You can't specify `", arg, "`` when simple = TRUE", call. = FALSE)
+        stop("You can't specify `", arg, "`` when simple = TRUE.", call. = FALSE)
       
       # checking num_arms and conditions consistency
       .check_ra_arg_num_arms_conditions(arg,
@@ -235,7 +237,7 @@ check_randomizr_arguments <-
            call. = FALSE)
     }
     if (!length(prob) %in% c(1)) {
-      stop("`prob` must be of length 1", call. = FALSE)
+      stop("`prob` must be of length 1.", call. = FALSE)
     }
   }
 
@@ -245,22 +247,47 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
-           prob_unit) {
+           prob_unit,
+           simple) {
+    browser()
     if (any(prob_unit > 1 | prob_unit < 0)) {
       stop("The probability of assignment to treatment must be between 0 and 1.",
            call. = FALSE)
     }
     
+    # if it's complete
+    if (!simple) {
+      if (is.null(blocks)) {
+        if (!is_constant(prob_unit)) {
+          stop(
+            "In a complete random assignment design, `prob_unit` must be the same for all units.",
+            call. = FALSE
+          )
+        }
+      } else{
+        # if it's blocked
+        if (!all(tapply(
+          X = prob_unit,
+          INDEX = blocks,
+          FUN = is_constant
+        ))) {
+          stop(
+            "In a block random assignment design, `prob_unit` must be the same for all units within the same block.",
+            call. = FALSE
+          )
+        }
+      }
+    }
     
     # if it's clustered:
     if (!is.null(clusters)) {
       if (!length(prob_unit) %in% length(clusters)) {
-        stop("`prob_unit` must be of length N", call. = FALSE)
+        stop("`prob_unit` must be of length N.", call. = FALSE)
       }
       
     } else{
       if (!length(prob_unit) %in% c(N)) {
-        stop("`prob_unit` must be of length N", call. = FALSE)
+        stop("`prob_unit` must be of length N.", call. = FALSE)
       }
     }
   }
@@ -299,7 +326,7 @@ check_randomizr_arguments <-
       }
     }
     else
-      stop("`prob_each` must be a vector or matrix", call. = FALSE)
+      stop("`prob_each` must be a vector or matrix.", call. = FALSE)
     
     
   }
@@ -351,7 +378,7 @@ check_randomizr_arguments <-
     if (is.null(blocks)) {
       if (!is_constant(m_unit)) {
         stop(
-          "In a complete random assignment design, `m_unit` must be the same for all units",
+          "In a complete random assignment design, `m_unit` must be the same for all units.",
           call. = FALSE
         )
       }
@@ -359,7 +386,7 @@ check_randomizr_arguments <-
       # if it's blocked
       if (!all(tapply(X = m_unit, INDEX = blocks, FUN = is_constant))) {
         stop(
-          "In a block random assignment design, `m_unit` must be the same for all units within the same block",
+          "In a block random assignment design, `m_unit` must be the same for all units within the same block.",
           call. = FALSE
         )
       }
@@ -368,7 +395,7 @@ check_randomizr_arguments <-
     # if it's clustered:
     if (!is.null(clusters)) {
       if (!length(m_unit) %in% length(clusters)) {
-        stop("`m_unit` must be of length N", call. = FALSE)
+        stop("`m_unit` must be of length N.", call. = FALSE)
       }
       
     } else{
@@ -392,7 +419,7 @@ check_randomizr_arguments <-
     }
     if (sum(m_each) != N) {
       stop(
-        "The sum of the number assigned to each condition (m_each) must equal the total number of units (N)",
+        "The sum of the number assigned to each condition (m_each) must equal the total number of units (N).",
         call. = FALSE
       )
     }
@@ -436,7 +463,7 @@ check_randomizr_arguments <-
     }
     if (nrow(block_prob_each) != attr(blocks, "N_blocks")) {
       stop(
-        "If specified, block_prob_each should have the same number of rows as there are unique blocks in blocks",
+        "If specified, block_prob_each should have the same number of rows as there are unique blocks in blocks.",
         call. = FALSE
       )
     }
@@ -538,7 +565,7 @@ check_samplr_arguments <- function(N = NULL,
     if (is.null(N)) {
       N <- sum(N_per_stratum)
     } else if (N != sum(N_per_stratum)) {
-      stop("N should equal the length of strata", call. = FALSE)
+      stop("N should equal the length of strata.", call. = FALSE)
     }
     attributes(strata) <-
       list(N_strata = N_strata, N_per_stratum = N_per_stratum)
@@ -546,7 +573,7 @@ check_samplr_arguments <- function(N = NULL,
   
   
   if (length(N) != 1 || N != floor(N) || N <= 0) {
-    stop("N must be an integer greater than 0", call. = FALSE)
+    stop("N must be an integer greater than 0.", call. = FALSE)
   }
   
   conflict_args <- c("prob", "n", "strata_prob", "strata_n")
@@ -585,26 +612,42 @@ check_samplr_arguments <- function(N = NULL,
          call. = FALSE)
   }
   if (!length(prob) %in% c(1)) {
-    stop("`prob` must be of length 1", call. = FALSE)
+    stop("`prob` must be of length 1.", call. = FALSE)
   }
 }
 
 .check_rs$prob_unit <- function(N, strata, clusters, prob_unit) {
   if (any(prob_unit > 1 | prob_unit < 0)) {
-    stop("The probability of assignment to treatment must be between 0 and 1.",
+    stop("The probability of being sampled must be between 0 and 1.",
          call. = FALSE)
   }
-  
+  # if it's complete
+  if (is.null(strata)) {
+    if (!is_constant(prob_unit)) {
+      stop(
+        "In a complete random sampling design, `prob_unit` must be the same for all units.",
+        call. = FALSE
+      )
+    }
+  } else{
+    # if it's blocked
+    if (!all(tapply(X = prob_unit, INDEX = strata, FUN = is_constant))) {
+      stop(
+        "In a stratified random assignment design, `prob_unit` must be the same for all units within the same stratum",
+        call. = FALSE
+      )
+    }
+  }
   
   # if it's clustered:
   if (!is.null(clusters)) {
     if (!length(prob_unit) %in% length(clusters)) {
-      stop("`prob_unit` must be of length N", call. = FALSE)
+      stop("`prob_unit` must be of length N.", call. = FALSE)
     }
     
   } else{
     if (!length(prob_unit) %in% c(N)) {
-      stop("`prob_unit` must be of length N", call. = FALSE)
+      stop("`prob_unit` must be of length N.", call. = FALSE)
     }
   }
   
@@ -661,7 +704,7 @@ check_samplr_arguments <- function(N = NULL,
     if (is.null(strata)) {
       if (!is_constant(n_unit)) {
         stop(
-          "In a complete random sampling design, `n_unit` must be the same for all units",
+          "In a complete random sampling design, `n_unit` must be the same for all units.",
           call. = FALSE
         )
       }
@@ -669,7 +712,7 @@ check_samplr_arguments <- function(N = NULL,
       # if it's stratified
       if (!all(tapply(X = n_unit, INDEX = strata, FUN = is_constant))) {
         stop(
-          "In a stratified random sampling design, `n_unit` must be the same for all units within the same stratum",
+          "In a stratified random sampling design, `n_unit` must be the same for all units within the same stratum.",
           call. = FALSE
         )
       }
@@ -678,12 +721,12 @@ check_samplr_arguments <- function(N = NULL,
     # if it's clustered:
     if (!is.null(clusters)) {
       if (!length(n_unit) %in% length(clusters)) {
-        stop("`n_unit` must be of length N", call. = FALSE)
+        stop("`n_unit` must be of length N.", call. = FALSE)
       }
       
     } else{
       if (!length(n_unit) %in% c(N)) {
-        stop("`n_unit` must be of length N", call. = FALSE)
+        stop("`n_unit` must be of length N.", call. = FALSE)
       }
     }
     

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -3,23 +3,19 @@
 
 
 
+
 # Call check() with all formal arguments of the invoking function
 # reinsert results into that environment
 .invoke_check <- function(check) {
-  browser()
   definition <- sys.function(sys.parent())
   envir <- parent.frame(1)
-  
   all_args <- mget(names(formals(definition)), envir)
-  if(blah) all_args$simple <- TRUE
   ret <- check(all_args)
   list2env(ret, envir)
   invisible(NULL)
 }
 
 #f <- function(N,n) {.invoke_check(function(a) list(n = a[["n"]] + 1)); n}
-
-
 
 check_randomizr_arguments_new <-
   function(all_args)
@@ -142,7 +138,14 @@ check_randomizr_arguments <-
                                         specified_args[[1]],
                                         num_arms,
                                         conditions)
-      .check_ra[[arg]](N, blocks, clusters, num_arms, conditions, specified_args[[1]])
+      
+      .check_ra[[arg]](N,
+                       blocks,
+                       clusters,
+                       num_arms,
+                       conditions,
+                       simple,
+                       specified_args[[1]])
       
     }
     
@@ -231,6 +234,7 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
+           simple,
            prob) {
     if (any(prob > 1 | prob < 0)) {
       stop("The probability of assignment to treatment must be between 0 and 1.",
@@ -247,35 +251,34 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
-           prob_unit,
-           simple) {
-    browser()
+           simple,
+           prob_unit) {
     if (any(prob_unit > 1 | prob_unit < 0)) {
       stop("The probability of assignment to treatment must be between 0 and 1.",
            call. = FALSE)
     }
     
     # if it's complete
-    if (!simple) {
-      if (is.null(blocks)) {
+    if (is.null(blocks)) {
+      if (!is.null(simple) && !simple) {
         if (!is_constant(prob_unit)) {
           stop(
             "In a complete random assignment design, `prob_unit` must be the same for all units.",
             call. = FALSE
           )
         }
-      } else{
-        # if it's blocked
-        if (!all(tapply(
-          X = prob_unit,
-          INDEX = blocks,
-          FUN = is_constant
-        ))) {
-          stop(
-            "In a block random assignment design, `prob_unit` must be the same for all units within the same block.",
-            call. = FALSE
-          )
-        }
+      }
+    } else{
+      # if it's blocked
+      if (!all(tapply(
+        X = prob_unit,
+        INDEX = blocks,
+        FUN = is_constant
+      ))) {
+        stop(
+          "In a block random assignment design, `prob_unit` must be the same for all units within the same block.",
+          call. = FALSE
+        )
       }
     }
     
@@ -298,6 +301,7 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
+           simple,
            prob_each) {
     if (any(prob_each > 1 | prob_each < 0)) {
       stop(
@@ -337,6 +341,7 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
+           simple,
            m) {
     if (length(m) != 1) {
       stop("If specified, the number of units assigned to treatment (m) must be a scalar.",
@@ -373,6 +378,7 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
+           simple,
            m_unit) {
     # if it's complete
     if (is.null(blocks)) {
@@ -412,6 +418,7 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
+           simple,
            m_each) {
     if (any(m_each < 0)) {
       stop("The number of units assigned to all conditions must be nonnegative.",
@@ -431,6 +438,7 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
+           simple,
            block_prob) {
     if (any(block_prob > 1 | block_prob < 0)) {
       stop(
@@ -454,6 +462,7 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
+           simple,
            block_prob_each) {
     if (any(block_prob_each < 0 | block_prob_each > 1)) {
       stop(
@@ -482,6 +491,7 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
+           simple,
            block_m) {
     if (length(block_m) != attr(blocks, "N_blocks")) {
       stop(
@@ -503,6 +513,7 @@ check_randomizr_arguments <-
            clusters,
            num_arms,
            conditions,
+           simple,
            block_m_each) {
     if (nrow(block_m_each) != attr(blocks, "N_blocks")) {
       stop(
@@ -525,136 +536,153 @@ check_samplr_arguments_new <- function(all_args) {
   do.call("check_samplr_arguments", all_args)
 }
 
-check_samplr_arguments <- function(N = NULL,
-                                   prob = NULL,
-                                   n = NULL,
-                                   strata = NULL,
-                                   strata_n = NULL,
-                                   strata_prob = NULL,
-                                   clusters = NULL,
-                                   simple = NULL,
-                                   ...)
-{
-  if (!is.null(clusters)) {
-    N <- length(unique(clusters))
-  }
-  
-  if (!is.null(strata)) {
-    if (isTRUE(simple))
-      stop("You can't specify 'simple' with strata.", call. = FALSE)
-    
+check_samplr_arguments <- 
+  function(N = NULL,
+           prob = NULL,
+           prob_unit = NULL,
+           n = NULL,
+           n_unit = NULL,
+           strata = NULL,
+           strata_n = NULL,
+           strata_prob = NULL,
+           clusters = NULL,
+           simple = NULL,
+           ...) {
     
     if (!is.null(clusters)) {
-      N_per_stratum <-
-        tapply(clusters, strata, function(x)
-          length(unique(x)))
-      attributes(N_per_stratum) <- NULL
+      N <- length(unique(clusters))
+    }
+    
+    if (!is.null(strata)) {
+      if (isTRUE(simple))
+        stop("You can't specify 'simple' with strata.", call. = FALSE)
       
-      # N would be set by clusters check abovew
-      if (any(colSums(table(strata, clusters) > 0) > 1)) {
-        stop("All units within a cluster must be in the same stratum.",
-             call. = FALSE)
+      if (!is.null(clusters)) {
+        N_per_stratum <-
+          tapply(clusters, strata, function(x)
+            length(unique(x)))
+        attributes(N_per_stratum) <- NULL
+        
+        # N would be set by clusters check abovew
+        if (any(colSums(table(strata, clusters) > 0) > 1)) {
+          stop("All units within a cluster must be in the same stratum.",
+               call. = FALSE)
+        }
+      } else {
+        N_per_stratum <- tapply(strata, strata, length)
+        attributes(N_per_stratum) <- NULL
       }
-    } else {
-      N_per_stratum <- tapply(strata, strata, length)
-      attributes(N_per_stratum) <- NULL
+      
+      N_strata <- length(N_per_stratum)
+      
+      if (is.null(N)) {
+        N <- sum(N_per_stratum)
+      } else if (N != sum(N_per_stratum)) {
+        stop("N should equal the length of strata.", call. = FALSE)
+      }
+      attributes(strata) <-
+        list(N_strata = N_strata, N_per_stratum = N_per_stratum)
     }
     
-    N_strata <- length(N_per_stratum)
-    
-    if (is.null(N)) {
-      N <- sum(N_per_stratum)
-    } else if (N != sum(N_per_stratum)) {
-      stop("N should equal the length of strata.", call. = FALSE)
+    if (length(N) != 1 || N != floor(N) || N <= 0) {
+      stop("N must be an integer greater than 0.", call. = FALSE)
     }
-    attributes(strata) <-
-      list(N_strata = N_strata, N_per_stratum = N_per_stratum)
-  }
-  
-  
-  if (length(N) != 1 || N != floor(N) || N <= 0) {
-    stop("N must be an integer greater than 0.", call. = FALSE)
-  }
-  
-  conflict_args <- c("prob", "n", "strata_prob", "strata_n")
-  specified_args <- Filter(Negate(is.null), mget(conflict_args))
-  
-  if (length(specified_args) > 1) {
-    stop("Please specify only one of ",
-         paste(names(specified_args), collapse = " and "),
-         ".",
-         call. = FALSE)
-  } else if (length(specified_args) == 1) {
-    arg <- names(specified_args)
     
-    if (isTRUE(simple) &&
-        !grepl("prob", arg))
-      stop("You can't specify `", arg, "` when simple = TRUE.", call. = FALSE)
+    conflict_args <- c("prob", "prob_unit", "n", "n_unit", "strata_prob", "strata_n")
+    specified_args <- Filter(Negate(is.null), mget(conflict_args))
     
-    .check_rs[[arg]](N, strata, clusters, specified_args[[1]])
+    if (length(specified_args) > 1) {
+      stop("Please specify only one of ",
+           paste(names(specified_args), collapse = " and "),
+           ".",
+           call. = FALSE)
+    } else if (length(specified_args) == 1) {
+      arg <- names(specified_args)
+      
+      if (isTRUE(simple) &&
+          !grepl("prob", arg))
+        stop("You can't specify `", arg, "` when simple = TRUE.", call. = FALSE)
+      
+      
+      .check_rs[[arg]](N, strata, clusters, simple, specified_args[[1]])
+    }
+    
+    list(
+      num_arms = 2,
+      conditions =  0:1,
+      condition_names = 0:1,
+      N_per_stratum = get0("N_per_stratum")
+    )
+    
   }
-  
-  list(
-    num_arms = 2,
-    conditions =  0:1,
-    condition_names = 0:1,
-    N_per_stratum = get0("N_per_stratum")
-  )
-  
-}
 
 # rs specific arg checks
 .check_rs <- new.env(parent = emptyenv())
 
-.check_rs$prob <- function(N, strata, clusters, prob) {
-  if (any(prob > 1 | prob < 0)) {
-    stop("The probability of assignment to treatment must be between 0 and 1.",
-         call. = FALSE)
+.check_rs$prob <-
+  function(N,
+           strata,
+           clusters,
+           simple,
+           prob) {
+    if (any(prob > 1 | prob < 0)) {
+      stop("The probability of assignment to treatment must be between 0 and 1.",
+           call. = FALSE)
+    }
+    if (!length(prob) %in% c(1)) {
+      stop("`prob` must be of length 1.", call. = FALSE)
+    }
   }
-  if (!length(prob) %in% c(1)) {
-    stop("`prob` must be of length 1.", call. = FALSE)
-  }
-}
 
-.check_rs$prob_unit <- function(N, strata, clusters, prob_unit) {
-  if (any(prob_unit > 1 | prob_unit < 0)) {
-    stop("The probability of being sampled must be between 0 and 1.",
-         call. = FALSE)
-  }
-  # if it's complete
-  if (is.null(strata)) {
-    if (!is_constant(prob_unit)) {
-      stop(
-        "In a complete random sampling design, `prob_unit` must be the same for all units.",
-        call. = FALSE
-      )
-    }
-  } else{
-    # if it's blocked
-    if (!all(tapply(X = prob_unit, INDEX = strata, FUN = is_constant))) {
-      stop(
-        "In a stratified random assignment design, `prob_unit` must be the same for all units within the same stratum",
-        call. = FALSE
-      )
-    }
-  }
-  
-  # if it's clustered:
-  if (!is.null(clusters)) {
-    if (!length(prob_unit) %in% length(clusters)) {
-      stop("`prob_unit` must be of length N.", call. = FALSE)
+.check_rs$prob_unit <-
+  function(N,
+           strata,
+           clusters,
+           simple,
+           prob_unit) {
+    if (any(prob_unit > 1 | prob_unit < 0)) {
+      stop("The probability of being sampled must be between 0 and 1.",
+           call. = FALSE)
     }
     
-  } else{
-    if (!length(prob_unit) %in% c(N)) {
-      stop("`prob_unit` must be of length N.", call. = FALSE)
+    # if it's complete
+    if (is.null(strata)) {
+      if (!is.null(simple) && !simple) {
+        if (!is_constant(prob_unit)) {
+          stop(
+            "In a complete random sampling design, `prob_unit` must be the same for all units.",
+            call. = FALSE
+          )
+        }
+      }
+    } else{
+      # if it's strata
+      if (!all(tapply(X = prob_unit, INDEX = strata, FUN = is_constant))) {
+        stop(
+          "In a stratified random assignment design, `prob_unit` must be the same for all units within the same stratum.",
+          call. = FALSE
+        )
+      }
+    }
+    # if it's clustered:
+    if (!is.null(clusters)) {
+      if (!length(prob_unit) %in% length(clusters)) {
+        stop("`prob_unit` must be of length N.", call. = FALSE)
+      }
+      
+    } else{
+      if (!length(prob_unit) %in% c(N)) {
+        stop("`prob_unit` must be of length N.", call. = FALSE)
+      }
     }
   }
-  
-}
 
 .check_rs$strata_prob <-
-  function(N, strata, clusters, strata_prob) {
+  function(N, 
+           strata, 
+           clusters, 
+           simple,
+           strata_prob) {
     if (any(strata_prob > 1 | strata_prob < 0)) {
       stop("The probabilities of being sampled must be between 0 and 1 for all strata.",
            call. = FALSE)
@@ -665,40 +693,45 @@ check_samplr_arguments <- function(N = NULL,
         call. = FALSE
       )
     }
-    
   }
 
 
-.check_rs$n <- function(N, strata, clusters, n) {
-  if (n < 0) {
-    stop("If specified, the number of units sampled (n) must be nonnegative.",
-         call. = FALSE)
-  }
-  if (n != floor(n)) {
-    stop("If specified, the number of units sampled (n) must be an integer.",
-         call. = FALSE)
-  }
-  if (is.null(strata)) {
-    if (n > N) {
-      stop(
-        "If specified, the number of units sampled (n) must not be greater than the total number of units (N).",
-        call. = FALSE
-      )
+.check_rs$n <- 
+  function(N, 
+           strata, 
+           clusters, 
+           simple,
+           n) {
+    if (n < 0) {
+      stop("If specified, the number of units sampled (n) must be nonnegative.",
+           call. = FALSE)
     }
-  } else {
-    if (n > min(attr(strata, "N_per_stratum"))) {
-      stop(
-        "If specified, the number of units sampled (n) must not be greater than the number of units in a strata (N).",
-        call. = FALSE
-      )
+    if (n != floor(n)) {
+      stop("If specified, the number of units sampled (n) must be an integer.",
+           call. = FALSE)
+    }
+    if (is.null(strata)) {
+      if (n > N) {
+        stop(
+          "If specified, the number of units sampled (n) must not be greater than the total number of units (N).",
+          call. = FALSE
+        )
+      }
+    } else {
+      if (n > min(attr(strata, "N_per_stratum"))) {
+        stop(
+          "If specified, the number of units sampled (n) must not be greater than the number of units in a strata (N).",
+          call. = FALSE
+        )
+      }
     }
   }
-}
 
 .check_rs$n_unit <-
   function(N,
            strata,
            clusters,
+           simple,
            n_unit) {
     # if it's complete
     if (is.null(strata)) {
@@ -729,42 +762,46 @@ check_samplr_arguments <- function(N = NULL,
         stop("`n_unit` must be of length N.", call. = FALSE)
       }
     }
+  }
+
+
+.check_rs$strata_n <- 
+  function(N, 
+           strata, 
+           clusters, 
+           simple,
+           strata_n) {
+    if (length(strata_n) != attr(strata, "N_strata")) {
+      stop(
+        "If specified, strata_n should have the same length as there are unique strata in strata.",
+        call. = FALSE
+      )
+    }
+    if (any(strata_n > attr(strata, "N_per_stratum") |
+            strata_n < 0)) {
+      stop(
+        "The number of units sampled within a stratum must be nonnegative and not exceed the total number units within the strata.",
+        call. = FALSE
+      )
+    }
+  }
+
+
+clean_condition_names <- 
+  function(assignment, conditions) {
+    if (is.factor(conditions)) {
+      return(factor(assignment, levels = levels(conditions)))
+    }
     
+    if (is.numeric(assignment)) {
+      return(assignment)
+    }
+    
+    if (is.logical(assignment)) {
+      return(as.numeric(assignment))
+    }
+    return(factor(assignment, levels = conditions))
   }
-
-
-.check_rs$strata_n <- function(N, strata, clusters, strata_n) {
-  if (length(strata_n) != attr(strata, "N_strata")) {
-    stop(
-      "If specified, strata_n should have the same length as there are unique strata in strata.",
-      call. = FALSE
-    )
-  }
-  if (any(strata_n > attr(strata, "N_per_stratum") |
-          strata_n < 0)) {
-    stop(
-      "The number of units sampled within a stratum must be nonnegative and not exceed the total number units within the strata.",
-      call. = FALSE
-    )
-  }
-}
-
-
-clean_condition_names <- function(assignment, conditions) {
-  if (is.factor(conditions)) {
-    return(factor(assignment, levels = levels(conditions)))
-  }
-  
-  if (is.numeric(assignment)) {
-    return(assignment)
-  }
-  
-  if (is.logical(assignment)) {
-    return(as.numeric(assignment))
-  }
-  
-  return(factor(assignment, levels = conditions))
-}
 
 is_constant <- function(x)
   all(x[1] == x)

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -260,7 +260,7 @@ check_randomizr_arguments <-
     
     # if it's complete
     if (is.null(blocks)) {
-      if (!is.null(simple) && !simple) {
+      if (!isTRUE(simple)) {
         if (!is_constant(prob_unit)) {
           stop(
             "In a complete random assignment design, `prob_unit` must be the same for all units.",
@@ -644,10 +644,9 @@ check_samplr_arguments <-
       stop("The probability of being sampled must be between 0 and 1.",
            call. = FALSE)
     }
-    
     # if it's complete
     if (is.null(strata)) {
-      if (!is.null(simple) && !simple) {
+      if (!isTRUE(simple)) {
         if (!is_constant(prob_unit)) {
           stop(
             "In a complete random sampling design, `prob_unit` must be the same for all units.",

--- a/R/simple_ra.R
+++ b/R/simple_ra.R
@@ -12,6 +12,7 @@
 #' @param num_arms The number of treatment arms. If unspecified, num_arms will be determined from the other arguments. (optional)
 #' @param conditions A character vector giving the names of the treatment groups. If unspecified, the treatment groups will be named 0 (for control) and 1 (for treatment) in a two-arm trial and T1, T2, T3, in a multi-arm trial. An exception is a two-group design in which num_arms is set to 2, in which case the condition names are T1 and T2, as in a multi-arm trial with two arms. (optional)
 #' @param check_inputs logical. Defaults to TRUE.
+#' @param simple logical. internal use only.
 #'
 #' @return A vector of length N that indicates the treatment condition of each unit. Is numeric in a two-arm trial and a factor variable (ordered by conditions) in a multi-arm trial.
 #' @export
@@ -48,7 +49,8 @@ simple_ra <- function(N,
                       prob_each = NULL,
                       num_arms = NULL,
                       conditions = NULL,
-                      check_inputs = TRUE) {
+                      check_inputs = TRUE,
+                      simple = TRUE) {
   if (check_inputs) {
     .invoke_check(check_randomizr_arguments_new)
   }

--- a/R/simple_ra.R
+++ b/R/simple_ra.R
@@ -99,7 +99,8 @@ simple_ra_probabilities <-
            prob_each = NULL,
            num_arms = NULL,
            conditions = NULL,
-           check_inputs = TRUE) {
+           check_inputs = TRUE, 
+           simple = TRUE) {
     if (check_inputs) .invoke_check(check_randomizr_arguments_new)
     
     # Three easy cases

--- a/R/simple_rs.R
+++ b/R/simple_rs.R
@@ -6,6 +6,7 @@
 #' @param prob prob is the probability of being sampled must be a real number between 0 and 1 inclusive, and must be of length 1. (optional)
 #' @param prob_unit prob is the probability of being sampled must be a real number between 0 and 1 inclusive, and must be of length N. (optional)
 #' @param check_inputs logical. Defaults to TRUE.
+#' @param simple logical. internal use only.
 #'
 #' @return A numeric vector of length N that indicates if a unit is sampled (1) or not (0).
 #' @export
@@ -18,7 +19,12 @@
 #' S <- simple_rs(N = 100, prob = 0.3)
 #' table(S)
 #'
-simple_rs <- function(N, prob = NULL, prob_unit = NULL, check_inputs = TRUE) {
+simple_rs <- 
+  function(N, 
+           prob = NULL, 
+           prob_unit = NULL, 
+           check_inputs = TRUE,
+           simple = TRUE) {
   if(check_inputs) .invoke_check(check_samplr_arguments_new)
   if(is.null(prob)) prob <- .5
   simple_ra(N, prob, prob_unit, conditions=0:1, check_inputs = FALSE)    

--- a/R/simple_rs.R
+++ b/R/simple_rs.R
@@ -43,8 +43,8 @@ simple_rs <-
 #' table(probs)
 #'
 #' @export
-simple_rs_probabilities <- function(N, prob = NULL, prob_unit = NULL, check_inputs = TRUE) {
+simple_rs_probabilities <- function(N, prob = NULL, prob_unit = NULL, check_inputs = TRUE, simple = TRUE) {
   if(check_inputs) .invoke_check(check_samplr_arguments_new)
   if(is.null(prob)) prob <- .5
-  simple_ra_probabilities(N, prob, prob_unit, conditions = 0:1, check_inputs = FALSE)[,2]
+  simple_ra_probabilities(N, prob, prob_unit, conditions = 0:1, check_inputs = FALSE, simple = TRUE)[,2]
 }

--- a/R/strata_rs.R
+++ b/R/strata_rs.R
@@ -28,8 +28,16 @@
 #'
 #' Z <- strata_rs(strata = strata, strata_prob = c(.1, .2, .3))
 #' table(strata, Z)
+#' 
+#' Z <- strata_rs(strata = strata, 
+#'                prob_unit = rep(c(.1, .2, .3), times = c(50, 100, 200)))
+#' table(strata, Z)
 #'
 #' Z <- strata_rs(strata = strata, strata_n = c(20, 30, 40))
+#' table(strata, Z)
+#' 
+#' Z <- strata_rs(strata = strata, 
+#'                n_unit = rep(c(20, 30, 40), times = c(50, 100, 200)))
 #' table(strata, Z)
 #'
 #'

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 # # For each _ra/_rs function,
-# # generate a generic 
+# # generate a generic
 # # dump them out to generated_methods.R
 # # Need to temporarily export custom_ra
 # 
@@ -8,42 +8,42 @@
 # .invoke <- function(f){
 #   what <- names(formals(match.fun(f)))
 #   fun <- function(this){
-#     
-#   }  
+# 
+#   }
 #   args <- lapply(setNames(nm=what), function(x) call("[[", as.symbol("this"), x) )
-#   
+# 
 #   body(fun) <- as.call(append(as.symbol(f), args))
-#   
+# 
 #   fun
 # }
 # 
 # .out <- new.env(parent = emptyenv())
 # 
 # for (.f in ls(pattern=.pattern, asNamespace("randomizr"))) {
-#   
+# 
 # 
 #     .fclass <- sub(.pattern, "", .f)
 #     .fgeneric <- regmatches(.f, regexec(.pattern, .f))[[1]]
-#     
+# 
 #     if(.fclass %in% c("declare", "draw", "conduct")) next;
-#     
-#     .fclass <- switch(.fclass, 
-#                       block_and_cluster="blocked_and_clustered", 
-#                       block="blocked", 
-#                       cluster="clustered", 
+# 
+#     .fclass <- switch(.fclass,
+#                       block_and_cluster="blocked_and_clustered",
+#                       block="blocked",
+#                       cluster="clustered",
 #                       strata="stratified",
 #                       strata_and_cluster="stratified_and_clustered",
 #                       .fclass)
-#     
+# 
 #     if(.fgeneric[3] == "") .fgeneric[3] = "_function"
 # 
 #     .f2 <- sprintf("%s%s.%s_%s", .fgeneric[2], .fgeneric[3], .fgeneric[2], .fclass)
 #     message(.f, " -> ",  .f2)
-#     
+# 
 #     assign(.f2, .invoke(.f), .out)
 # 
-#   
-#   
+# 
+# 
 # }
 # 
 # dump(ls(.out), file = "R/generated_methods.R", envir = .out)

--- a/man/block_ra.Rd
+++ b/man/block_ra.Rd
@@ -56,10 +56,20 @@ table(blocks, Z)
 Z <- block_ra(blocks = blocks, block_prob = c(.1, .2, .3))
 table(blocks, Z)
 
+Z <- block_ra(blocks = blocks, 
+              prob_unit = rep(c(.1, .2, .3), 
+                              times = c(50, 100, 200)))
+table(blocks, Z)
+
 Z <- block_ra(blocks = blocks, m = 20)
 table(blocks, Z)
 
 Z <- block_ra(blocks = blocks, block_m = c(20, 30, 40))
+table(blocks, Z)
+
+Z <- block_ra(blocks = blocks, 
+              m_unit = rep(c(20, 30, 40),
+                           times = c(50, 100, 200)))
 table(blocks, Z)
 
 block_m_each <- rbind(c(25, 25),

--- a/man/complete_ra.Rd
+++ b/man/complete_ra.Rd
@@ -48,7 +48,13 @@ table(Z)
 Z <- complete_ra(N = 100, m = 50)
 table(Z)
 
+Z <- complete_ra(N = 100, m_unit = rep(50, 100))
+table(Z)
+
 Z <- complete_ra(N = 100, prob = .111)
+table(Z)
+
+Z <- complete_ra(N = 100, prob_unit = rep(0.1, 100))
 table(Z)
 
 Z <- complete_ra(N = 100, conditions = c("control", "treatment"))

--- a/man/complete_rs.Rd
+++ b/man/complete_rs.Rd
@@ -37,7 +37,13 @@ table(S)
 S <- complete_rs(N = 100, n = 50)
 table(S)
 
+S <- complete_rs(N = 100, n_unit = rep(50, 100))
+table(S)
+
 S <- complete_rs(N = 100, prob = .111)
+table(S)
+
+S <- complete_rs(N = 100, prob_unit = rep(.1, 100))
 table(S)
 
 # If N = n, sample with 100\% probability...

--- a/man/simple_ra.Rd
+++ b/man/simple_ra.Rd
@@ -5,7 +5,8 @@
 \title{Simple Random Assignment}
 \usage{
 simple_ra(N, prob = NULL, prob_unit = NULL, prob_each = NULL,
-  num_arms = NULL, conditions = NULL, check_inputs = TRUE)
+  num_arms = NULL, conditions = NULL, check_inputs = TRUE,
+  simple = TRUE)
 }
 \arguments{
 \item{N}{The number of units. N must be a positive integer. (required)}
@@ -21,6 +22,8 @@ simple_ra(N, prob = NULL, prob_unit = NULL, prob_each = NULL,
 \item{conditions}{A character vector giving the names of the treatment groups. If unspecified, the treatment groups will be named 0 (for control) and 1 (for treatment) in a two-arm trial and T1, T2, T3, in a multi-arm trial. An exception is a two-group design in which num_arms is set to 2, in which case the condition names are T1 and T2, as in a multi-arm trial with two arms. (optional)}
 
 \item{check_inputs}{logical. Defaults to TRUE.}
+
+\item{simple}{logical. internal use only.}
 }
 \value{
 A vector of length N that indicates the treatment condition of each unit. Is numeric in a two-arm trial and a factor variable (ordered by conditions) in a multi-arm trial.

--- a/man/simple_ra_probabilities.Rd
+++ b/man/simple_ra_probabilities.Rd
@@ -6,7 +6,7 @@
 \usage{
 simple_ra_probabilities(N, prob = NULL, prob_unit = NULL,
   prob_each = NULL, num_arms = NULL, conditions = NULL,
-  check_inputs = TRUE)
+  check_inputs = TRUE, simple = TRUE)
 }
 \arguments{
 \item{N}{The number of units. N must be a positive integer. (required)}
@@ -22,6 +22,8 @@ simple_ra_probabilities(N, prob = NULL, prob_unit = NULL,
 \item{conditions}{A character vector giving the names of the treatment groups. If unspecified, the treatment groups will be named 0 (for control) and 1 (for treatment) in a two-arm trial and T1, T2, T3, in a multi-arm trial. An exception is a two-group design in which num_arms is set to 2, in which case the condition names are T1 and T2, as in a multi-arm trial with two arms. (optional)}
 
 \item{check_inputs}{logical. Defaults to TRUE.}
+
+\item{simple}{logical. internal use only.}
 }
 \value{
 A matrix of probabilities of assignment

--- a/man/simple_rs.Rd
+++ b/man/simple_rs.Rd
@@ -4,7 +4,8 @@
 \alias{simple_rs}
 \title{Simple Random Sampling}
 \usage{
-simple_rs(N, prob = NULL, prob_unit = NULL, check_inputs = TRUE)
+simple_rs(N, prob = NULL, prob_unit = NULL, check_inputs = TRUE,
+  simple = TRUE)
 }
 \arguments{
 \item{N}{The number of units. N must be a positive integer. (required)}
@@ -14,6 +15,8 @@ simple_rs(N, prob = NULL, prob_unit = NULL, check_inputs = TRUE)
 \item{prob_unit}{prob is the probability of being sampled must be a real number between 0 and 1 inclusive, and must be of length N. (optional)}
 
 \item{check_inputs}{logical. Defaults to TRUE.}
+
+\item{simple}{logical. internal use only.}
 }
 \value{
 A numeric vector of length N that indicates if a unit is sampled (1) or not (0).

--- a/man/simple_rs_probabilities.Rd
+++ b/man/simple_rs_probabilities.Rd
@@ -5,7 +5,7 @@
 \title{Inclusion Probabilities: Simple Random Sampling}
 \usage{
 simple_rs_probabilities(N, prob = NULL, prob_unit = NULL,
-  check_inputs = TRUE)
+  check_inputs = TRUE, simple = TRUE)
 }
 \arguments{
 \item{N}{The number of units. N must be a positive integer. (required)}
@@ -15,6 +15,8 @@ simple_rs_probabilities(N, prob = NULL, prob_unit = NULL,
 \item{prob_unit}{prob is the probability of being sampled must be a real number between 0 and 1 inclusive, and must be of length N. (optional)}
 
 \item{check_inputs}{logical. Defaults to TRUE.}
+
+\item{simple}{logical. internal use only.}
 }
 \value{
 A vector length N indicating the probability of being sampled.

--- a/man/strata_rs.Rd
+++ b/man/strata_rs.Rd
@@ -46,7 +46,15 @@ table(strata, Z)
 Z <- strata_rs(strata = strata, strata_prob = c(.1, .2, .3))
 table(strata, Z)
 
+Z <- strata_rs(strata = strata, 
+               prob_unit = rep(c(.1, .2, .3), times = c(50, 100, 200)))
+table(strata, Z)
+
 Z <- strata_rs(strata = strata, strata_n = c(20, 30, 40))
+table(strata, Z)
+
+Z <- strata_rs(strata = strata, 
+               n_unit = rep(c(20, 30, 40), times = c(50, 100, 200)))
 table(strata, Z)
 
 

--- a/tests/testthat/test-block_ra.R
+++ b/tests/testthat/test-block_ra.R
@@ -205,9 +205,16 @@ test_that("prob_unit and m_unit", {
   expect_equal(table(blocks, Z), structure(c(45L, 80L, 140L, 5L, 20L, 60L), .Dim = 3:2, .Dimnames = list(
     blocks = c("A", "B", "C"), Z = c("0", "1")), class = "table"))
   
+  expect_error(block_ra(blocks = blocks, prob_unit = rep(c(.1, .2, .3), c(200, 100, 50))),
+               "In a block random assignment design, `prob_unit` must be the same for all units within the same block.")
+  
+  
   Z <- block_ra(blocks = blocks, m_unit = rep(c(20, 20, 25), c(50, 100, 200)))
   expect_equal(table(blocks, Z), structure(c(30L, 80L, 175L, 20L, 20L, 25L), .Dim = 3:2, .Dimnames = list(
     blocks = c("A", "B", "C"), Z = c("0", "1")), class = "table"))
+  
+  expect_error(block_ra(blocks = blocks, m_unit = rep(c(20, 20, 25), c(200, 100, 50))), 
+               "In a block random assignment design, `m_unit` must be the same for all units within the same block.")
 })
 
 

--- a/tests/testthat/test-cluster_rs.R
+++ b/tests/testthat/test-cluster_rs.R
@@ -1,9 +1,7 @@
 
-
 context("Cluster Random Sampling")
 clusters <- rep(letters[1:15], times = 1:15)
 
-#debugonce(cluster_rs_probabilities)
 test_that("Two Group Designs", {
   S <- cluster_rs(clusters = clusters)
   probs <- cluster_rs_probabilities(clusters = clusters)

--- a/tests/testthat/test-complete_ra.R
+++ b/tests/testthat/test-complete_ra.R
@@ -1,7 +1,3 @@
-
-
-
-
 context("Complete Random Assignments")
 
 test_that("Invalid complete RAs", {
@@ -197,7 +193,7 @@ test_that("_unit",{
   expect_error(complete_ra(100, prob_unit = rep(c(0.4, 0.5), c(50, 50))))
   
   table(complete_ra(100, m_unit = rep(40, 100)))
-  expect_warning(expect_error(table(complete_ra(100, m = rep(40, 100)))))
-  expect_error(complete_ra(100, m_unit = rep(c(40, 50), c(50, 50))))
+  expect_error(complete_ra(100, m = rep(40, 100)), "scalar.")
+  expect_error(complete_ra(100, m_unit = rep(c(40, 50), c(50, 50))), "In a complete random assignment design, `m_unit` must be the same for all units.")
 })
 

--- a/tests/testthat/test-simple_rs.R
+++ b/tests/testthat/test-simple_rs.R
@@ -29,7 +29,8 @@ test_that("SRS probs .1", {
 
 test_that("Weighted rs", {
   
-  p1 <- simple_rs_probabilities(N=4, prob_unit =1:4/4)
+  
+  p1 <- simple_rs_probabilities(N = 4, prob_unit = 1:4 / 4)
 
   expect_equal(p1, 1:4/4)
   

--- a/tests/testthat/test-strata_rs.R
+++ b/tests/testthat/test-strata_rs.R
@@ -75,15 +75,31 @@ test_that("prob_unit and n_unit", {
   strata <- rep(c("A", "B", "C"), times = c(50, 100, 200))
   
   S <- strata_rs(strata = strata, prob_unit = rep(c(.1, .2, .3), c(50, 100, 200)))
-  expect_equal(table(strata, S), structure(c(45L, 80L, 140L, 5L, 20L, 60L), .Dim = 3:2, .Dimnames = list(
-    strata = c("A", "B", "C"), S = c("0", "1")), class = "table"))
+  
+  expect_equal(table(strata, S),
+               structure(
+                 c(45L, 80L, 140L, 5L, 20L, 60L),
+                 .Dim = 3:2,
+                 .Dimnames = list(strata = c("A", "B", "C"), S = c("0", "1")),
+                 class = "table"
+               ))
+  
+  expect_error(
+    strata_rs(strata = strata, prob_unit = rep(c(.1, .2, .3), c(200, 100, 50))),
+    "In a stratified random assignment design, `prob_unit` must be the same for all units within the same stratum."
+  )
+  
   
   S <- strata_rs(strata = strata, n_unit = rep(c(20, 20, 25), c(50, 100, 200)))
+  
   expect_equal(table(strata, S), 
                structure(c(30L, 80L, 175L, 20L, 20L, 25L), .Dim = 3:2, .Dimnames = list(
                  strata = c("A", "B", "C"), S = c("0", "1")), class = "table"))
+  
+  expect_error(
+    strata_rs(strata = strata, n_unit = rep(c(20, 20, 25), c(200, 100, 50))),
+    "In a stratified random sampling design, `n_unit` must be the same for all units within the same stratum."
+  )
+  
 })
-
-
-
 

--- a/tests/testthat/test_assignment_declarations.R
+++ b/tests/testthat/test_assignment_declarations.R
@@ -434,3 +434,19 @@ test_that("print and summary", {
   expect_output(print(d))
   expect_output(summary(d))
 })
+
+
+test_that("_unit",{
+  blocks <- rep(c("A", "B", "C"), times = c(50, 100, 200))
+  d <- declare_ra(blocks = blocks, prob_unit = rep(c(.1, .2, .3), c(50, 100, 200)))
+  expect_equal(table(blocks, conduct_ra(d)),
+               structure(
+                 c(45L, 80L, 140L, 5L, 20L, 60L),
+                 .Dim = 3:2,
+                 .Dimnames = list(blocks = c("A", "B", "C"), c("0", "1")),
+                 class = "table"
+               ))
+  expect_error(declare_ra(blocks = blocks, prob_unit = rep(c(.1, .2, .3), c(200, 100, 50))))
+})
+
+

--- a/tests/testthat/test_sampling_declarations.R
+++ b/tests/testthat/test_sampling_declarations.R
@@ -138,3 +138,18 @@ test_that("print and summary", {
   expect_output(summary(d))
 })
 
+
+test_that("_each",{
+  
+  strata <- rep(c("A", "B", "C"), times = c(50, 100, 200))
+  d <- declare_rs(strata = strata, n_unit = rep(c(20, 20, 25), c(50, 100, 200)))
+  
+  expect_equal(table(strata, draw_rs(d)), 
+               structure(c(30L, 80L, 175L, 20L, 20L, 25L), .Dim = 3:2, .Dimnames = list(
+                 strata = c("A", "B", "C"), c("0", "1")), class = "table"))
+  
+  expect_error(
+    declare_rs(strata = strata, n_unit = rep(c(20, 20, 25), c(200, 100, 50))),
+    "In a stratified random sampling design, `n_unit` must be the same for all units within the same stratum."
+  )
+})


### PR DESCRIPTION
The main trouble was telling the check functions about whether the design was "simple" or not.  If the design is simple, then prob_unit can be different for each unit.  If the design is complete, blocked, stratified, what have out, then prob_unit has to be constant within block, or cluster or block and cluster.

We've got decent test coverage on these too, I think!