### PR TITLE
Synchronize RNG state.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: randomizr
 Title: Easy-to-Use Tools for Common Forms of Random Assignment and Sampling
-Version: 0.18.0
+Version: 0.19.0
 Authors@R: c(person("Alexander", "Coppock", email = "acoppock@gmail.com", role = c("aut", "cre")),
              person("Jasper", "Cooper", email = "jaspercooper@gmail.com", role = c("ctb")),
              person("Neal", "Fultz", email = "nfultz@gmail.com", role = c("ctb"), comment = "C version of restricted partitions"))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@
 init:
   ps: |
         $ErrorActionPreference = "SilentlyContinue"
-        Invoke-WebRequest http://raw.github.com/nfultz/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
 
 install:

--- a/src/vsample.c
+++ b/src/vsample.c
@@ -16,6 +16,8 @@ SEXP randomizr_vsample(SEXP pmat) {
   
   int* out = INTEGER(ret);
   
+  GetRNGstate();
+  
   for(i = 0; i < m; i++) {
     double r = unif_rand();
     for(j = 0; r > 0 && j < n; j++) {
@@ -24,6 +26,8 @@ SEXP randomizr_vsample(SEXP pmat) {
     
     out[i] = j;
   }
+  
+  PutRNGstate();
 
   UNPROTECT(1);  
   

--- a/tests/testthat/test-tricky-examples.R
+++ b/tests/testthat/test-tricky-examples.R
@@ -189,3 +189,15 @@ test_that("balancing with block_prob_each", {
   
   expect_true(all (table(blocks, draw) - golden %in% -1:1))
 })
+
+
+
+test_that("vsample advances rng", {
+  s1 <- .Random.seed
+  
+  complete_ra(5)
+  s2 <- .Random.seed
+  
+  expect_true(!identical(s1, s2))
+})
+  


### PR DESCRIPTION
This fixes the issue originally reported in [estimatr](https://github.com/DeclareDesign/estimatr/issues/308)

only complete_ra is affected AFAICT, and only if people are calling it repeatedly in a row without touching the RNG via other functions but also triggering an unkown rlang / Rcpp condition.