### PR TITLE
Use ATX-style headings

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,6 +1,9 @@
 ---
 output:
-  github_document
+  github_document:
+    pandoc_args: [
+      "markdown-headings", "atx"
+    ]
 title: "randomizr: Easy to use tools for common forms of random assignment and sampling"
 ---
 


### PR DESCRIPTION
Instruct Pandoc to use ATX-style (#-prefixed) headings such that {randomizr}'s pkdown website displays the heading as such